### PR TITLE
feat(products): add support for displaying product offers

### DIFF
--- a/src/core/products/domain/models/Product.ts
+++ b/src/core/products/domain/models/Product.ts
@@ -7,4 +7,5 @@ export interface Product {
     sku: string;
     category: string;
     stock: number;
+    offers: any
 }


### PR DESCRIPTION
Introduce a new `offers` field in the `Product` interface to store offer details. Add styles and utility functions in `ProductList` to calculate and display offer percentages and time left. Update the socket URL to use the configured API URL. This change enhances the product display by showcasing active offers.